### PR TITLE
🧹 refactor: replace context.TODO() with context.Background() in k8s example

### DIFF
--- a/examples/k8s-client-go/simple-clientset/main.go
+++ b/examples/k8s-client-go/simple-clientset/main.go
@@ -61,7 +61,7 @@ func main() {
 		panic(err.Error())
 	}
 	for {
-		pods, err := clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
+		pods, err := clientset.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			panic(err.Error())
 		}
@@ -72,7 +72,7 @@ func main() {
 		// - And/or cast to StatusError and use its properties like e.g. ErrStatus.Message
 		namespace := "default"
 		pod := "example-xxxxx"
-		_, err = clientset.CoreV1().Pods(namespace).Get(context.TODO(), pod, metav1.GetOptions{})
+		_, err = clientset.CoreV1().Pods(namespace).Get(context.Background(), pod, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			fmt.Printf("Pod %s in namespace %s not found\n", pod, namespace)
 		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {


### PR DESCRIPTION
🎯 **What:** Replaced `context.TODO()` with `context.Background()` in the `List` and `Get` Kubernetes API calls in `examples/k8s-client-go/simple-clientset/main.go`.
💡 **Why:** `context.Background()` is the correct top-level context for long-running processes or main routines. `context.TODO()` should only be used as a temporary placeholder during development. This change improves code health and aligns with standard Go conventions.
✅ **Verification:** Ran `go build ./...` in the `examples/k8s-client-go` directory to ensure the code compiles without errors. The code review also confirmed the change is safe and correct.
✨ **Result:** The code is cleaner, more robust, and properly utilizes context variables without altering runtime behavior.

---
*PR created automatically by Jules for task [4294997681838150165](https://jules.google.com/task/4294997681838150165) started by @anfernee*