### PR TITLE
Fix 2048 to prevent spawning new tiles when no movement occurs

### DIFF
--- a/2048.js
+++ b/2048.js
@@ -211,6 +211,9 @@ class Grid {
           cur = next_cur;
           moved = true;
         } else {
+          if (cur.cell.x != cell.x || cur.cell.y != cell.y) {
+            moved = true;
+          }
           this.assign(cur, cell);
           cur = next;
         }
@@ -385,7 +388,8 @@ class Game {
   }
 
   move(dir) {
-    this.grid.move(dir);
+    let moved = this.grid.move(dir);
+    if (!moved) return;
     this.renderer.render();
     if (this.new_tile() == Game.GAME_OVER) {
       this.keyboard.remove("move");


### PR DESCRIPTION
Fix 2048 to prevent spawning new tiles when no movement occurs

Modified the `move` logic in `2048.js` to ensure the grid only registers a move when tiles physically slide to a new position or merge. Further updated the main game loop to ignore arrow key inputs that don't result in any grid state changes, successfully preventing the spawn of new tiles on invalid directions.

---
*PR created automatically by Jules for task [14230251399276100004](https://jules.google.com/task/14230251399276100004) started by @anfernee*